### PR TITLE
Make green article box on home page more opaque

### DIFF
--- a/themes/snap_bootstrap/sass/_snap_articles.scss
+++ b/themes/snap_bootstrap/sass/_snap_articles.scss
@@ -6,7 +6,7 @@
 	border: 2px solid #fff;
 	text-align: center;
 	background: $snapGreen;
-	opacity: 0.8;
+	opacity: 0.9;
 	width: 30em;
 	min-height: 5em;
 	padding: .5em;


### PR DESCRIPTION
Addresses #311. Opacity of green box changed from 80% to 90%.
